### PR TITLE
Add result_cache to function get_measurement_master

### DIFF
--- a/cost-accounting/plsql/bb_measurement.body.sql
+++ b/cost-accounting/plsql/bb_measurement.body.sql
@@ -3,6 +3,7 @@ is
   unmatch_m_type_exception exception;
 
   function get_measurement_master(unit varchar2) return measurement_master%rowtype
+  result_cache
   is
     entity measurement_master%rowtype;
   begin


### PR DESCRIPTION
PL/SQL版のget_measurement_masterにfunction result cacheを適用するパッチです。

PL/pgSQLにも同様の機能が存在しないか調べたのですが、今のところないようです...。
