### PR TITLE
Fix executeSequential with JDBC mode

### DIFF
--- a/cost-accounting/java/example-nedo/src/main/java/com/example/nedo/batch/task/BenchBatchJdbcFactoryTask.java
+++ b/cost-accounting/java/example-nedo/src/main/java/com/example/nedo/batch/task/BenchBatchJdbcFactoryTask.java
@@ -49,7 +49,7 @@ public class BenchBatchJdbcFactoryTask extends BenchBatchFactoryTask {
 				commitOrRollback(count);
 			} catch (Throwable t) {
 				try {
-					connection.rollback();
+					doRollback();
 				} catch (Throwable s) {
 					t.addSuppressed(s);
 				}
@@ -127,19 +127,15 @@ public class BenchBatchJdbcFactoryTask extends BenchBatchFactoryTask {
 
 	@Override
 	protected void doCommit() {
-		try {
-			connection.commit();
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		}
+		LocalTransactionDataSource dataSource = AppConfig.singleton().getDataSource();
+		LocalTransaction transaction = dataSource.getLocalTransaction(AppConfig.singleton().getJdbcLogger());
+		transaction.commit();
 	}
 
 	@Override
 	protected void doRollback() {
-		try {
-			connection.rollback();
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		}
+		LocalTransactionDataSource dataSource = AppConfig.singleton().getDataSource();
+		LocalTransaction transaction = dataSource.getLocalTransaction(AppConfig.singleton().getJdbcLogger());
+		transaction.rollback();
 	}
 }


### PR DESCRIPTION
JDBC版でコミットやロールバック操作をConnectionではなくDoma2のLocalTransactionに対して行う変更です。

JDBC版で `batch.factory-task.type` を `1` (sequential) で実行すると、
Doma2のローカルトランザクションを重複して開始した旨のエラーが出てエラー終了する問題を修正するものです。

commitのほうは動作確認済みですが、rollbackのほうは動作確認していません...。
