### PR TITLE
Add configuration `batch.parallelism`

### DIFF
--- a/cost-accounting/java/example-nedo/src/main/java/com/example/nedo/BenchConst.java
+++ b/cost-accounting/java/example-nedo/src/main/java/com/example/nedo/BenchConst.java
@@ -51,6 +51,10 @@ public class BenchConst {
 		return getPropertyInt("batch.factory-task.type", 1);
 	}
 
+	public static int batchParallelism() {
+		return getPropertyInt("batch.parallelism", 0);
+	}
+
 	public static int DECIMAL_SCALE = getPropertyInt("decimal.scale", 20);
 
 	// online

--- a/cost-accounting/java/example-nedo/src/main/java/com/example/nedo/batch/BenchBatch.java
+++ b/cost-accounting/java/example-nedo/src/main/java/com/example/nedo/batch/BenchBatch.java
@@ -142,7 +142,12 @@ public class BenchBatch {
 		List<BenchBatchFactoryTask> threadList = factoryList.stream()
 				.map(factoryId -> newBenchBatchFactoryThread(batchDate, factoryId)).collect(Collectors.toList());
 
-		ExecutorService pool = Executors.newFixedThreadPool(factoryList.size());
+		int batchParallelism = BenchConst.batchParallelism();
+		if (batchParallelism <= 0) {
+			batchParallelism = factoryList.size();
+		}
+
+		ExecutorService pool = Executors.newFixedThreadPool(batchParallelism);
 		List<Future<Void>> resultList = Collections.emptyList();
 		try {
 			resultList = pool.invokeAll(threadList);


### PR DESCRIPTION
Java版のワーカースレッド数を指定するための設定項目 `batch.parallelism` を追加します。

これまでJava版のワーカースレッド数はベンチマーク起動時に指定する工場数と同数になっていますが、
工場数は固定にしてワーカースレッド数を変更する(例、120の工場を4スレッドで処理する)ことで、
データサイズを固定化して並列数にフォーカスした性能傾向を把握することが可能になります。

`batch.parallelism` に0以下を指定した場合、従来と同様に工場数がワーカースレッド数になります。
また、プロパティファイルに `batch.parallelism` を設定しない場合、デフォルト値として `0` を設定します。
これらにより、この変更を適用した後でもこれまで使用していたプロパティファイルをそのまま使う場合は、
ベンチマークの挙動に変更がないようにしています。

ドキュメント化する適当な場所が見当たらなかったのでとりあえずドキュメントは書いていません。
（ 他の `batch.xxx` の設定項目もドキュメント化されていない）
