### PR TITLE
Add JAVA_OPTS for setting jvm options

### DIFF
--- a/cost-accounting/java/example-nedo/src/dist/bin/exec-batch.sh
+++ b/cost-accounting/java/example-nedo/src/dist/bin/exec-batch.sh
@@ -12,7 +12,7 @@ fi
 
 function call_java() {
   echo $1
-  java -cp "$BASEDIR/*:$BASEDIR/lib/*" -Dproperty="$PROPERTY" $@
+  java -cp "$BASEDIR/*:$BASEDIR/lib/*" $JAVA_OPTS -Dproperty="$PROPERTY" $@
 }
 
 call_java com.example.nedo.batch.BenchBatch 2020-09-15 "all" 100

--- a/cost-accounting/java/example-nedo/src/dist/bin/exec-online.sh
+++ b/cost-accounting/java/example-nedo/src/dist/bin/exec-online.sh
@@ -12,7 +12,7 @@ fi
 
 function call_java() {
   echo $1
-  java -cp "$BASEDIR/*:$BASEDIR/lib/*" -Dproperty="$PROPERTY" $@
+  java -cp "$BASEDIR/*:$BASEDIR/lib/*" $JAVA_OPTS -Dproperty="$PROPERTY" $@
 }
 
 call_java com.example.nedo.online.BenchOnline 2020-09-15 "1-2,3-4,5-6"

--- a/cost-accounting/java/example-nedo/src/dist/bin/initdata.sh
+++ b/cost-accounting/java/example-nedo/src/dist/bin/initdata.sh
@@ -12,7 +12,7 @@ fi
 
 function call_java() {
   echo $1
-  java -cp "$BASEDIR/*:$BASEDIR/lib/*" -Dproperty="$PROPERTY" $1
+  java -cp "$BASEDIR/*:$BASEDIR/lib/*" $JAVA_OPTS -Dproperty="$PROPERTY" $1
 }
 
 call_java com.example.nedo.init.InitialData01MeasurementMaster


### PR DESCRIPTION
Java上で実行するベンチマークの各アプリケーションに対して
JVMオプションを環境変数 `JAVA_OPTS` で設定可能にします。

各起動スクリプトで環境変数名を分けるか悩みましたが、
こちらでは分ける必要がなかったのでとりあえず全部同じ環境変数名にしています。
