### PR TITLE
Use Gradle Application Plugin for distribution

### DIFF
--- a/java/cost-accounting-benchmark/build.gradle
+++ b/java/cost-accounting-benchmark/build.gradle
@@ -1,8 +1,6 @@
 plugins {
-    id 'java'
-
-    id 'java-library-distribution'
-
+    id 'java-library'
+    id 'application'
     id 'com.diffplug.eclipse.apt' version '3.24.0'
     id 'com.github.spotbugs' version '4.7.1'
 }
@@ -119,4 +117,10 @@ task showIceaxeManifest {
         def version = resources.text.fromArchiveEntry(iceaxeJar, "META-INF/MANIFEST.MF")
         print(version.asString())
     }
+}
+
+startScripts {
+    applicationName = 'costaccounting'
+    mainClass = 'com.tsurugidb.benchmark.costaccounting.Main'
+    applicationDefaultJvmArgs = ['-Dcom.tsurugidb.tsubakuro.jniverify=false']
 }

--- a/java/cost-accounting-benchmark/src/dist/bin/run.sh
+++ b/java/cost-accounting-benchmark/src/dist/bin/run.sh
@@ -12,14 +12,5 @@ fi
 
 shift
 
-function call_java() {
-  xTXLOG_OPTS="
-    -Diceaxe.tx.log.dir=/tmp/iceaxe-tx-log
-    -Diceaxe.tx.log.auto_flush=true
-    -Diceaxe.tx.log.explain=0
-    -Diceaxe.tx.log.read_progress=100000
-    "
-  java -cp "$BASEDIR/*:$BASEDIR/lib/*" $JAVA_OPTS -Dproperty="$PROPERTY" $TXLOG_OPTS $RUN_JAVA_OPTS $@
-}
-
-call_java com.tsurugidb.benchmark.costaccounting.Main $@
+export COSTACCOUNTING_OPTS="-Dproperty=${PROPERTY} ${COSTACCOUNTING_OPTS}"
+./costaccounting $@


### PR DESCRIPTION
ベンチマークアプリケーションのリリース方法をGradle Application Pluginを使う方法に統一するための `build.gradle` の修正です。
