### PR TITLE
Change distTar.archiveFileName to tar.gz

### DIFF
--- a/java/cost-accounting-benchmark/build.gradle
+++ b/java/cost-accounting-benchmark/build.gradle
@@ -124,3 +124,9 @@ startScripts {
     mainClass = 'com.tsurugidb.benchmark.costaccounting.Main'
     applicationDefaultJvmArgs = ['-Dcom.tsurugidb.tsubakuro.jniverify=false']
 }
+
+distTar {
+    archiveFileName = "${project.name}.tar.gz"
+    archiveExtension = 'tar.gz'
+    compression = Compression.GZIP
+}

--- a/java/cost-accounting-benchmark/readme.md
+++ b/java/cost-accounting-benchmark/readme.md
@@ -36,7 +36,7 @@ ls build/distributions/
 実行環境で解凍する。
 
 ```bash
-tar xf cost-accounting-benchmark.tar
+tar xf cost-accounting-benchmark.tar.gz
 cd cost-accounting-benchmark/bin
 chmod +x *.sh
 ```


### PR DESCRIPTION
Gradleの `distTar` タスクで生成されるtarballを `.tar` から `.tar.gz` に変更します。