### PR TITLE
ci: modify runs-on for preventing ubuntu-latest

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
     timeout-minutes: 30


### PR DESCRIPTION
As ubuntu 24.04 is currently still experimental support

See: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes