### PR TITLE
build: change maven snapshot repository to central portal

### DIFF
--- a/java/cost-accounting-benchmark/build.gradle
+++ b/java/cost-accounting-benchmark/build.gradle
@@ -15,7 +15,7 @@ if (hasProperty('mavenLocal')) {
 } else {
     repositories {
         maven {
-            url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+            url 'https://central.sonatype.com/repository/maven-snapshots/'
             content {
                 includeGroupByRegex 'com\\.tsurugidb.*'
             }


### PR DESCRIPTION
This pull request changes the URL for the Maven snapshots repository for migrating OSSRH to Central Portal.