### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Setup_Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Assemble
         run: |
@@ -40,7 +40,7 @@ jobs:
           ./gradlew -i check --continue --warning-mode all
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()
         with:
           junit_input: 'java/cost-accounting-benchmark/build/test-results/**/TEST-*.xml'


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/